### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,35 @@
 {
-    "name": "giadc-redux-json-api",
-    "version": "0.3.1",
-    "description": "Reducer, actions, and helper functions for managing JSON API entities in Redux",
-    "main": "./lib/giadc-redux-json-api.js",
-    "scripts": {
-        "build": "babel --presets es2015,stage-0 -d lib/ src/",
-        "watch": "babel --watch --presets es2015,stage-0 -d lib/ src/",
-        "test": "mocha --require tests/.setup.js --compilers js:babel-core/register tests/*.test.js",
-        "test:watch": "mocha --require tests/.setup.js --compilers js:babel-core/register --watch tests/*.test.js",
-        "prepublish": "npm run build"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/giadc/giadc-redux-json-api.git"
-    },
-    "author": "Ryan Marganti <rmarganti@gannett.com>",
-    "license": "MIT",
-    "dependencies": {
-        "node-uuid": "^1.4.7",
-        "pluralize": "^1.2.1"
-    },
-    "devDependencies": {
-        "babel-cli": "^6.7.7",
-        "babel-preset-es2015": "^6.6.0",
-        "babel-preset-stage-0": "^6.5.0",
-        "chai": "^3.5.0",
-        "eslint": "^3.6.0",
-        "eslint-config-airbnb": "^12.0.0",
-        "eslint-plugin-import": "^1.16.0",
-        "eslint-plugin-jsx-a11y": "^2.2.2",
-        "eslint-plugin-react": "^6.3.0",
-        "mocha": "^2.4.5"
-    }
+  "name": "giadc-redux-json-api",
+  "version": "0.3.1",
+  "description": "Reducer, actions, and helper functions for managing JSON API entities in Redux",
+  "main": "./lib/giadc-redux-json-api.js",
+  "scripts": {
+    "build": "babel --presets es2015,stage-0 -d lib/ src/",
+    "watch": "babel --watch --presets es2015,stage-0 -d lib/ src/",
+    "test": "mocha --require tests/.setup.js --compilers js:babel-core/register tests/*.test.js",
+    "test:watch": "mocha --require tests/.setup.js --compilers js:babel-core/register --watch tests/*.test.js",
+    "prepublish": "npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/giadc/giadc-redux-json-api.git"
+  },
+  "author": "Ryan Marganti <rmarganti@gannett.com>",
+  "license": "MIT",
+  "dependencies": {
+    "pluralize": "^1.2.1",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.7.7",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "chai": "^3.5.0",
+    "eslint": "^3.6.0",
+    "eslint-config-airbnb": "^12.0.0",
+    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-jsx-a11y": "^2.2.2",
+    "eslint-plugin-react": "^6.3.0",
+    "mocha": "^2.4.5"
+  }
 }
-

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,5 @@
 import pluralize from 'pluralize';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 
 /**
  * Grab an Entity from the state


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.